### PR TITLE
Level based suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ archivesBaseName = 'rate-limited-logger'
 version = '1.0'
 
 ext.packaging = 'jar'
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ archivesBaseName = 'rate-limited-logger'
 version = '1.0'
 
 ext.packaging = 'jar'
-sourceCompatibility = 1.8
+sourceCompatibility = 1.6
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/swrve/ratelimitedlogger/LogLevelHelper.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/LogLevelHelper.java
@@ -1,0 +1,35 @@
+package com.swrve.ratelimitedlogger;
+
+import org.slf4j.Logger;
+
+class LogLevelHelper {
+
+    public static enum Level {
+        TRACE, DEBUG, INFO, WARN, ERROR
+    }
+
+    private LogLevelHelper() {
+    }
+
+    public static void log(Logger logger, Level level, String msg, Object... arguments) {
+        if (logger != null && level != null) {
+            switch (level) {
+                case TRACE:
+                    logger.trace(msg, arguments);
+                    break;
+                case DEBUG:
+                    logger.debug(msg, arguments);
+                    break;
+                case INFO:
+                    logger.info(msg, arguments);
+                    break;
+                case WARN:
+                    logger.warn(msg, arguments);
+                    break;
+                case ERROR:
+                    logger.error(msg, arguments);
+                    break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/swrve/ratelimitedlogger/LogLevelHelper.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/LogLevelHelper.java
@@ -5,7 +5,17 @@ import org.slf4j.Logger;
 class LogLevelHelper {
 
     public static enum Level {
-        TRACE, DEBUG, INFO, WARN, ERROR
+
+        TRACE("trace"), DEBUG("debug"), INFO("info"), WARN("warn"), ERROR("error");
+        private final String levelName;
+
+        Level(String levelName) {
+            this.levelName = levelName;
+        }
+
+        public String getLevelName() {
+            return levelName;
+        }
     }
 
     private LogLevelHelper() {

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
@@ -1,5 +1,12 @@
 package com.swrve.ratelimitedlogger;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Stopwatch;
 import net.jcip.annotations.GuardedBy;
@@ -7,19 +14,18 @@ import net.jcip.annotations.ThreadSafe;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import static com.swrve.ratelimitedlogger.LogLevelHelper.Level;
 
 /**
  * An individual log pattern - the unit of rate limiting.  Each object is rate-limited individually.
- * <p/>
+ * <p>
  * These objects are thread-safe.
  */
 @ThreadSafe
 public class RateLimitedLogWithPattern {
+
     private static final long NOT_RATE_LIMITED_YET = 0L;
+    private static final String RATE_LIMITED_COUNT_SUFFIX = "_rate_limited_log_count";
 
     private final String message;
     private final RateAndPeriod rateAndPeriod;
@@ -30,7 +36,7 @@ public class RateLimitedLogWithPattern {
     /**
      * Number of observed logs in the current time period.
      */
-    private final AtomicInteger counter = new AtomicInteger(0); // mutable
+    private final ConcurrentMap<Level, AtomicLong> levelCounters = new ConcurrentHashMap<>();
 
     /**
      * When we exceed the rate limit during a period, we record when.  If the rate limit has not been exceeded, the
@@ -48,10 +54,10 @@ public class RateLimitedLogWithPattern {
 
     /**
      * logging APIs.
-     * <p/>
+     * <p>
      * These can use the SLF4J style of templating to parameterize the Logs.
      * See http://www.slf4j.org/api/org/slf4j/helpers/MessageFormatter.html .
-     * <p/>
+     * <p>
      * <pre>
      *    rateLimitedLog.info("Just saw an event of type {}: {}", event.getType(), event);
      * </pre>
@@ -59,41 +65,41 @@ public class RateLimitedLogWithPattern {
      * @param args the varargs list of arguments matching the message template
      */
     public void trace(Object... args) {
-        if (!isRateLimited()) {
+        if (!isRateLimited(Level.TRACE)) {
             logger.trace(message, args);
         }
-        incrementStats("trace");
+        incrementStats(Level.TRACE);
     }
 
     public void debug(Object... args) {
-        if (!isRateLimited()) {
+        if (!isRateLimited(Level.DEBUG)) {
             logger.debug(message, args);
         }
-        incrementStats("debug");
+        incrementStats(Level.DEBUG);
     }
 
     public void info(Object... args) {
-        if (!isRateLimited()) {
+        if (!isRateLimited(Level.INFO)) {
             logger.info(message, args);
         }
-        incrementStats("info");
+        incrementStats(Level.INFO);
     }
 
     public void warn(Object... args) {
-        if (!isRateLimited()) {
+        if (!isRateLimited(Level.WARN)) {
             logger.warn(message, args);
         }
-        incrementStats("warn");
+        incrementStats(Level.WARN);
     }
 
     public void error(Object... args) {
-        if (!isRateLimited()) {
+        if (!isRateLimited(Level.ERROR)) {
             logger.error(message, args);
         }
-        incrementStats("error");
+        incrementStats(Level.ERROR);
     }
 
-    private boolean isRateLimited() {
+    private boolean isRateLimited(Level level) {
 
         // note: this method is not synchronized, for performance.  If we exceed the maxRate, we will start checking
         // haveExceededLimit, and if that's still false, we enter the synchronized haveJustExceededRateLimit() method.
@@ -105,7 +111,12 @@ public class RateLimitedLogWithPattern {
         // when haveJustExceededRateLimit() eventually got to execute.  We will also potentially log a small
         // number more lines to the logger than the rate limit allows.
         //
-        int count = counter.incrementAndGet();
+        AtomicLong counter = levelCounters.get(level);
+        if (counter == null) {
+            levelCounters.putIfAbsent(level, new AtomicLong(0L));
+            counter = levelCounters.get(level);
+        }
+        long count = counter.incrementAndGet();
         if (count < rateAndPeriod.maxRate) {
             return false;
         } else if (count >= rateAndPeriod.maxRate && rateLimitedAt.get() == NOT_RATE_LIMITED_YET) {
@@ -128,14 +139,19 @@ public class RateLimitedLogWithPattern {
 
     @GuardedBy("this")
     private void reportSuppression(long whenLimited) {
-        int count = counter.get();
-        counter.addAndGet(-count);
-        int numSuppressed = count - rateAndPeriod.maxRate;
-        if (numSuppressed == 0) {
-            return;  // special case: we hit the rate limit, but did not actually exceed it -- nothing got suppressed, so there's no need to log
+        for (Level level : Level.values()) {
+            AtomicLong counter = levelCounters.get(level);
+            if (counter != null) {
+                long count = counter.get();
+                counter.addAndGet(-count);
+                long numSuppressed = count - rateAndPeriod.maxRate;
+                if (numSuppressed == 0) {
+                    return;  // special case: we hit the rate limit, but did not actually exceed it -- nothing got suppressed, so there's no need to log
+                }
+                Duration howLong = new Duration(whenLimited, elapsedMsecs());
+                LogLevelHelper.log(logger, level, "(suppressed {} logs similar to '{}' in {})", numSuppressed, message, howLong);
+            }
         }
-        Duration howLong = new Duration(whenLimited, elapsedMsecs());
-        logger.info("(suppressed " + numSuppressed + " logs similar to '" + message + "' in " + howLong + ")");
     }
 
     private synchronized void haveJustExceededRateLimit() {
@@ -154,17 +170,17 @@ public class RateLimitedLogWithPattern {
      * Increment a counter metric called "{level}_rate_limited_log_count", where "{level}" is the log
      * level in question.  This is still performed even when a log is rate limited, since incrementing
      * a counter metric is cheap!
-     * <p/>
+     * <p>
      * This deliberately doesn't attempt to use counter metrics named after the log message, since
      * extracting that without making a mess is complex, and if that's desired, it's easy enough
      * for calling code to do it instead.  As an "early warning" indicator that lots of logging
      * activity took place, this is useful enough.
      */
-    private void incrementStats(String level) {
+    private void incrementStats(Level level) {
         if (!stats.isPresent()) {
             return;
         }
-        stats.get().increment(level + "_rate_limited_log_count");
+        stats.get().increment(level.name() + RATE_LIMITED_COUNT_SUFFIX);
     }
 
     /**
@@ -173,8 +189,12 @@ public class RateLimitedLogWithPattern {
      */
     @Override
     public boolean equals(@Nullable Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         return (message.equals(((RateLimitedLogWithPattern) o).message));
     }
 
@@ -185,6 +205,7 @@ public class RateLimitedLogWithPattern {
 
 
     static final class RateAndPeriod {
+
         final int maxRate;
         final Duration periodLength;
 


### PR DESCRIPTION
The idea of pull request is that:
- `RateLimitedLogRegistry` should log with the same log level as original log messages. Many systems log to the different appenders based on log level, so this will make future investigation much easier. 
- Actually the same message logged with the different level should be considered as different messages. It really can be the case that the system might log the same message text under different levels based on some internal conditions, so we might log some `info` messages but miss `warning` or even `errors` which were suppressed.
