### PR TITLE
Upgrade to Java 8 and removed Guava and Jodatime dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ artifacts {
 }
 
 signing {
+    required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 // http://www.gradle.org/docs/current/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html
 apply plugin: 'findbugs'
 findbugs {
-    toolVersion = "2.0.3"
+    toolVersion = "3.0.1"
     effort = "max"
     reportLevel = "high"
     ignoreFailures = false

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ archivesBaseName = 'rate-limited-logger'
 version = '1.1.0'
 
 ext.packaging = 'jar'
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()
@@ -24,8 +24,6 @@ buildscript {
 
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
-    compile group: 'joda-time', name: 'joda-time', version: '2.3'
-    compile group: 'com.google.guava', name: 'guava', version: '15.0'
     compile group: 'findbugs', name: 'annotations', version: '1.0.0'
     compile group: 'com.google.code.findbugs', name: 'jsr305', version: '2.0.2'
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  java:
+    version: oraclejdk8
   environment:
     # Disable gradle fancy single line output
     TERM: dumb

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -71,22 +71,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>logback-classic</artifactId>
             <version>1.1.2</version>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>15.0</version>
-        </dependency>
     </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.5.1</jmh.version>
-        <javac.target>1.6</javac.target>
+        <javac.target>1.8</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 

--- a/jmh-tests/src/main/java/com/swrve/ratelimitedlogger/benchmarks/BenchLogWithPatternAndLevel.java
+++ b/jmh-tests/src/main/java/com/swrve/ratelimitedlogger/benchmarks/BenchLogWithPatternAndLevel.java
@@ -2,8 +2,9 @@ package com.swrve.ratelimitedlogger.benchmarks;
 
 import com.swrve.ratelimitedlogger.*;
 import com.swrve.ratelimitedlogger.Level;
-import org.joda.time.Duration;
 import org.openjdk.jmh.annotations.*;
+
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +15,7 @@ import org.slf4j.LoggerFactory;
 public class BenchLogWithPatternAndLevel {
     private static final Logger logger = LoggerFactory.getLogger(BenchLogWithPatternAndLevel.class);
     private static final RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                   .maxRate(1).every(Duration.standardSeconds(1000))
+                   .maxRate(1).every(Duration.ofSeconds(1000))
                    .build();
 
     private LogWithPatternAndLevel testMessage;

--- a/jmh-tests/src/main/java/com/swrve/ratelimitedlogger/benchmarks/BenchRateLimitedLogWithPattern.java
+++ b/jmh-tests/src/main/java/com/swrve/ratelimitedlogger/benchmarks/BenchRateLimitedLogWithPattern.java
@@ -2,8 +2,9 @@ package com.swrve.ratelimitedlogger.benchmarks;
 
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 import com.swrve.ratelimitedlogger.RateLimitedLogWithPattern;
-import org.joda.time.Duration;
 import org.openjdk.jmh.annotations.*;
+
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +15,7 @@ import org.slf4j.LoggerFactory;
 public class BenchRateLimitedLogWithPattern {
     private static final Logger logger = LoggerFactory.getLogger(BenchRateLimitedLogWithPattern.class);
     private static final RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                   .maxRate(1).every(Duration.standardSeconds(1000))
+                   .maxRate(1).every(Duration.ofSeconds(1000))
                    .build();
 
     private RateLimitedLogWithPattern testMessage;

--- a/jmh-tests/src/main/java/com/swrve/ratelimitedlogger/benchmarks/BenchWithStringKey.java
+++ b/jmh-tests/src/main/java/com/swrve/ratelimitedlogger/benchmarks/BenchWithStringKey.java
@@ -1,8 +1,9 @@
 package com.swrve.ratelimitedlogger.benchmarks;
 
 import com.swrve.ratelimitedlogger.RateLimitedLog;
-import org.joda.time.Duration;
 import org.openjdk.jmh.annotations.*;
+
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +14,7 @@ import org.slf4j.LoggerFactory;
 public class BenchWithStringKey {
     private static final Logger logger = LoggerFactory.getLogger(BenchWithStringKey.class);
     private static final RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                   .maxRate(1).every(Duration.standardSeconds(1000))
+                   .maxRate(1).every(Duration.ofSeconds(1000))
                    .build();
 
     @Setup

--- a/src/main/java/com/swrve/ratelimitedlogger/LogWithPatternAndLevel.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/LogWithPatternAndLevel.java
@@ -1,15 +1,13 @@
 package com.swrve.ratelimitedlogger;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-import com.google.common.base.Stopwatch;
-import net.jcip.annotations.GuardedBy;
-import net.jcip.annotations.ThreadSafe;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -29,7 +27,7 @@ public class LogWithPatternAndLevel {
     private final Level level;
     private final RateLimitedLogWithPattern.RateAndPeriod rateAndPeriod;
     private final Logger logger;
-    private final Optional<CounterMetric> stats;
+    private final CounterMetric stats;
     private final Stopwatch stopwatch;
 
     /**
@@ -45,7 +43,7 @@ public class LogWithPatternAndLevel {
 
     LogWithPatternAndLevel(String message, Level level,
                            RateLimitedLogWithPattern.RateAndPeriod rateAndPeriod,
-                           Optional<CounterMetric> stats,
+                           CounterMetric stats,
                            Stopwatch stopwatch, Logger logger) {
         this.message = message;
         this.level = level;
@@ -136,7 +134,7 @@ public class LogWithPatternAndLevel {
         if (numSuppressed == 0) {
             return;  // special case: we hit the rate limit, but did not actually exceed it -- nothing got suppressed, so there's no need to log
         }
-        Duration howLong = new Duration(whenLimited, elapsedMsecs());
+        Duration howLong = Duration.ofMillis(whenLimited).plusMillis(elapsedMsecs());
         level.log(logger, "(suppressed {} logs similar to '{}' in {})", numSuppressed, message, howLong);
     }
 
@@ -145,7 +143,7 @@ public class LogWithPatternAndLevel {
     }
 
     private long elapsedMsecs() {
-        long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+        long elapsed = stopwatch.elapsedTime(TimeUnit.MILLISECONDS);
         if (elapsed == NOT_RATE_LIMITED_YET) {
             elapsed++;  // avoid using the magic value by "rounding up"
         }
@@ -163,10 +161,11 @@ public class LogWithPatternAndLevel {
      * activity took place, this is useful enough.
      */
     private void incrementStats() {
-        if (!stats.isPresent()) {
-            return;
-        }
-        stats.get().increment(level.getLevelName() + RATE_LIMITED_COUNT_SUFFIX);
+        getStats().ifPresent(s -> s.increment(level.getLevelName() + RATE_LIMITED_COUNT_SUFFIX));
+    }
+
+    private Optional<CounterMetric> getStats() {
+        return Optional.ofNullable(stats);
     }
 
     /**
@@ -187,6 +186,8 @@ public class LogWithPatternAndLevel {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(message, level.ordinal());
+        int result = message.hashCode();
+        result = 31 * result + level.hashCode();
+        return result;
     }
 }

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLog.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLog.java
@@ -1,13 +1,10 @@
 package com.swrve.ratelimitedlogger;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
-import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -57,27 +54,26 @@ public class RateLimitedLog implements Logger {
      * probable that an already-interpolated string is accidentally being used as a
      * pattern.
      */
-    @VisibleForTesting
     static final int MAX_PATTERNS_PER_LOG = 1000;
 
     private final ConcurrentHashMap<String, RateLimitedLogWithPattern> knownPatterns
-            = new ConcurrentHashMap<String, RateLimitedLogWithPattern>();
+            = new ConcurrentHashMap<>();
 
     private final Logger logger;
     private final RateLimitedLogWithPattern.RateAndPeriod rateAndPeriod;
     private final Registry registry;
     private final Stopwatch stopwatch;
-    private final Optional<CounterMetric> stats;
+    private final CounterMetric stats;
 
     /**
      * Start building a new RateLimitedLog, wrapping the SLF4J logger @param logger.
      */
     public static RateLimitedLogBuilder.MissingRateAndPeriod withRateLimit(Logger logger) {
-        return new RateLimitedLogBuilder.MissingRateAndPeriod(Preconditions.checkNotNull(logger));
+        return new RateLimitedLogBuilder.MissingRateAndPeriod(Objects.requireNonNull(logger));
     }
 
     // package-local ctor called by the Builder
-    RateLimitedLog(Logger logger, RateLimitedLogWithPattern.RateAndPeriod rateAndPeriod, Stopwatch stopwatch, Optional<CounterMetric> stats, Registry registry) {
+    RateLimitedLog(Logger logger, RateLimitedLogWithPattern.RateAndPeriod rateAndPeriod, Stopwatch stopwatch, CounterMetric stats, Registry registry) {
         this.logger = logger;
         this.rateAndPeriod = rateAndPeriod;
         this.registry = registry;

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogBuilder.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogBuilder.java
@@ -2,6 +2,7 @@ package com.swrve.ratelimitedlogger;
 
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.time.Duration;
 import java.util.Objects;
@@ -16,7 +17,7 @@ public class RateLimitedLogBuilder {
     private final int maxRate;
     private final Duration periodLength;
     private Stopwatch stopwatch = new Stopwatch();
-    private CounterMetric stats;
+    private @Nullable CounterMetric stats = null;
 
     public static class MissingRateAndPeriod {
         private final Logger logger;

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
@@ -1,14 +1,12 @@
 package com.swrve.ratelimitedlogger;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Stopwatch;
-import net.jcip.annotations.ThreadSafe;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
@@ -23,18 +21,18 @@ public class RateLimitedLogWithPattern {
     private final RateAndPeriod rateAndPeriod;
     private final Logger logger;
     private final Registry registry;
-    private final Optional<CounterMetric> stats;
+    private final CounterMetric stats;
     private final Stopwatch stopwatch;
     private final AtomicReferenceArray<LogWithPatternAndLevel> levels;
 
-    RateLimitedLogWithPattern(String message, RateAndPeriod rateAndPeriod, Registry registry, Optional<CounterMetric> stats, Stopwatch stopwatch, Logger logger) {
+    RateLimitedLogWithPattern(String message, RateAndPeriod rateAndPeriod, Registry registry, CounterMetric stats, Stopwatch stopwatch, Logger logger) {
         this.message = message;
         this.rateAndPeriod = rateAndPeriod;
         this.registry = registry;
         this.logger = logger;
         this.stats = stats;
         this.stopwatch = stopwatch;
-        this.levels = new AtomicReferenceArray<LogWithPatternAndLevel>(Level.values().length);
+        this.levels = new AtomicReferenceArray<>(Level.values().length);
     }
 
     /**
@@ -175,7 +173,7 @@ public class RateLimitedLogWithPattern {
 
         boolean wasSet = levels.compareAndSet(l, null, newValue);
         if (!wasSet) {
-            return Preconditions.checkNotNull(levels.get(l));
+            return Objects.requireNonNull(levels.get(l));
         } else {
             // ensure we'll reset the counter once every period
             registry.register(newValue, rateAndPeriod.periodLength);

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
@@ -21,11 +21,11 @@ public class RateLimitedLogWithPattern {
     private final RateAndPeriod rateAndPeriod;
     private final Logger logger;
     private final Registry registry;
-    private final CounterMetric stats;
+    private final @Nullable CounterMetric stats;
     private final Stopwatch stopwatch;
     private final AtomicReferenceArray<LogWithPatternAndLevel> levels;
 
-    RateLimitedLogWithPattern(String message, RateAndPeriod rateAndPeriod, Registry registry, CounterMetric stats, Stopwatch stopwatch, Logger logger) {
+    RateLimitedLogWithPattern(String message, RateAndPeriod rateAndPeriod, Registry registry, @Nullable CounterMetric stats, Stopwatch stopwatch, Logger logger) {
         this.message = message;
         this.rateAndPeriod = rateAndPeriod;
         this.registry = registry;

--- a/src/main/java/com/swrve/ratelimitedlogger/Stopwatch.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/Stopwatch.java
@@ -1,0 +1,27 @@
+package com.swrve.ratelimitedlogger;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple stopwatch implementation to avoid Guava dependency
+ */
+public class Stopwatch {
+
+    private long startTime = 0L;
+
+    public Stopwatch() {
+        startTime = System.nanoTime();
+    }
+
+    public Stopwatch(long startTime) {
+        this.startTime = startTime;
+    }
+
+    public void start() {
+        startTime = System.nanoTime();
+    }
+
+    public long elapsedTime(TimeUnit timeUnit) {
+        return timeUnit.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+    }
+}

--- a/src/test/java/com/swrve/ratelimitedlogger/ManyThreadsTest.java
+++ b/src/test/java/com/swrve/ratelimitedlogger/ManyThreadsTest.java
@@ -1,8 +1,8 @@
 package com.swrve.ratelimitedlogger;
 
-import org.joda.time.Duration;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -18,7 +18,7 @@ public class ManyThreadsTest {
         MockLogger logger = new MockLogger();
 
         final RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(100))
+                .maxRate(1).every(Duration.ofMillis(100))
                 .build();
 
         final AtomicBoolean done = new AtomicBoolean(false);
@@ -27,13 +27,10 @@ public class ManyThreadsTest {
 
         ExecutorService exec = Executors.newFixedThreadPool(10);
         for (int thread = 0; thread < 10; thread++) {
-            exec.submit(new Runnable() {
-                @Override
-                public void run() {
-                    while (!done.get()) {
-                        for (int i = 0; i < 1000; i++) {
-                            rateLimitedLog.info("manyThreads {}", Thread.currentThread().getId());
-                        }
+            exec.submit(() -> {
+                while (!done.get()) {
+                    for (int i = 0; i < 1000; i++) {
+                        rateLimitedLog.info("manyThreads {}", Thread.currentThread().getId());
                     }
                 }
             });
@@ -59,7 +56,7 @@ public class ManyThreadsTest {
 
         // ensure that "similar messages suppressed" took place
         assertThat(logger.infoMessageCount, not(equalTo(c + 10)));
-        assertThat(logger.infoLastMessage.get(), startsWith("(suppressed "));
+        assertThat(logger.getInfoLastMessage().get(), startsWith("(suppressed "));
 
     }
 }

--- a/src/test/java/com/swrve/ratelimitedlogger/MockLogger.java
+++ b/src/test/java/com/swrve/ratelimitedlogger/MockLogger.java
@@ -1,10 +1,11 @@
 package com.swrve.ratelimitedlogger;
 
-import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.helpers.MessageFormatter;
+
+import java.util.Optional;
 
 /**
  * An implementation of Logger suitable for the rate-limited log unit tests
@@ -16,7 +17,7 @@ class MockLogger implements Logger {
     public int warnMessageCount;
     public int errorMessageCount;
     int traceMessageCount;
-    Optional<String> infoLastMessage;
+    String infoLastMessage;
 
     @Override
     public boolean isDebugEnabled() {
@@ -148,7 +149,7 @@ class MockLogger implements Logger {
     @Override
     public void info(String msg) {
         logger.info("[info] "+msg);
-        infoLastMessage = Optional.of(msg);
+        infoLastMessage = msg;
         infoMessageCount++;
     }
 
@@ -327,5 +328,9 @@ class MockLogger implements Logger {
     @Override
     public void warn(Marker marker, String msg, Throwable t) {
         throw new IllegalStateException("not supported");
+    }
+
+    public Optional<String> getInfoLastMessage() {
+        return Optional.of(infoLastMessage);
     }
 }

--- a/src/test/java/com/swrve/ratelimitedlogger/RateLimitedLogTest.java
+++ b/src/test/java/com/swrve/ratelimitedlogger/RateLimitedLogTest.java
@@ -1,10 +1,8 @@
 package com.swrve.ratelimitedlogger;
 
-import com.google.common.base.Stopwatch;
-import com.google.common.base.Ticker;
-import org.joda.time.Duration;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -20,7 +18,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -39,7 +37,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -53,7 +51,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(500))
+                .maxRate(1).every(Duration.ofMillis(500))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -86,7 +84,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(500))
+                .maxRate(1).every(Duration.ofMillis(500))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -126,7 +124,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(3).every(Duration.millis(500))
+                .maxRate(3).every(Duration.ofMillis(500))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -167,12 +165,12 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(200))
+                .maxRate(1).every(Duration.ofMillis(200))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
         RateLimitedLog rateLimitedLog2 = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(300))
+                .maxRate(1).every(Duration.ofMillis(300))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -205,14 +203,9 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
         final AtomicBoolean statsCalled = new AtomicBoolean(false);
 
-        CounterMetric mockStats = new CounterMetric() {
-            @Override
-            public void increment(String name) {
-                statsCalled.set(true);
-            }
-        };
+        CounterMetric mockStats = name -> statsCalled.set(true);
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .recordMetrics(mockStats)
                 .build();
@@ -233,7 +226,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -264,7 +257,7 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
@@ -297,13 +290,13 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
         mockTime.set(1L);
         rateLimitedLog.info("locale {}", 10000);
-        assertThat(logger.infoLastMessage.get(), equalTo("locale 10000"));
+        assertThat(logger.getInfoLastMessage().get(), equalTo("locale 10000"));
     }
 
     // Ensure that the out-of-cache-capacity logic doesn't lose data.
@@ -313,23 +306,18 @@ public class RateLimitedLogTest {
         final AtomicLong mockTime = new AtomicLong(0L);
 
         RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
-                .maxRate(1).every(Duration.millis(10))
+                .maxRate(1).every(Duration.ofMillis(10))
                 .withStopwatch(createStopwatch(mockTime))
                 .build();
 
         for (int i = 0; i < RateLimitedLog.MAX_PATTERNS_PER_LOG + 2; i++) {
             rateLimitedLog.info("cache " + i);
-            assertThat(logger.infoLastMessage.get(), equalTo("cache " + i)); // no loss
+            assertThat(logger.getInfoLastMessage().get(), equalTo("cache " + i)); // no loss
         }
     }
 
     private Stopwatch createStopwatch(final AtomicLong mockTime) {
-        return Stopwatch.createUnstarted(new Ticker() {
-            @Override
-            public long read() {
-                return mockTime.get();
-            }
-        });
+        return new Stopwatch(mockTime.get());
     }
 
 }


### PR DESCRIPTION
# Context
This idea is to build a dependency free version of rate limited logger. The main objective is to make it easier to use it in projects where transitive dependencies are a mess to manage (ex : big data project using Hadoop or Spark).

# Changes
## Jodatime
All usages of Jodatime were replaced by the Java Time API
## Guava
Guava optional were replaced with Java standard Optional type. Optional is not used as a field anymore as it is considered an anti pattern.
A light ThreadFactory was introduced to replace Guava's.
A really light implementation of a Stopwatch is used to replace Guava's.
Preconditions are mostly replaced by Objects.requireNonNull or custom checks