### PR TITLE
Switch from JSR-305 javax findbugs/spotbugs annotations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,18 @@
 version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build:
+
     environment:
       # Configure the JVM and Gradle to avoid OOM errors
       _JAVA_OPTIONS: "-Xmx2g"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+
     docker: # run the steps with Docker
       - image: circleci/openjdk:11.0.3-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-      - image: circleci/postgres:12-alpine
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: circle_test
+
     steps: # a collection of executable commands
       - checkout # check out source code to working directory
       # Read about caching dependencies: https://circleci.com/docs/2.0/caching/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs: # a collection of steps
       - restore_cache:
           key: v1-gradle-cache-{{ checksum "build.gradle" }}
       - run:
-          name: Run tests in parallel # See: https://circleci.com/docs/2.0/parallelism-faster-jobs/
+          name: Run tests # See: https://circleci.com/docs/2.0/parallelism-faster-jobs/
           # Use "./gradlew test" instead if tests are not run in parallel
           command: |
             ./gradlew test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,91 +1,62 @@
-# This configuration was automatically generated from a CircleCI 1.0 config.
-# It should include any build commands you had along with commands that CircleCI
-# inferred from your project structure. We strongly recommend you read all the
-# comments in this file to understand the structure of CircleCI 2.0, as the idiom
-# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
-# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
-# configuration as a reference rather than using it in production, though in most
-# cases it should duplicate the execution of your original 1.0 config.
-version: 2
-jobs:
+version: 2 # use CircleCI 2.0
+jobs: # a collection of steps
   build:
-    working_directory: ~/Swrve/rate-limited-logger
-    parallelism: 1
-    shell: /bin/bash --login
-    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
-    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
     environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-      TERM: dumb
-    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
-    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
-    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
-    # We have selected a pre-built image that mirrors the build environment we use on
-    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
-    # of each job. For more information on choosing an image (or alternatively using a
-    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
-    # To see the list of pre-built images that CircleCI provides for most common languages see
-    # https://circleci.com/docs/2.0/circleci-images/
-    docker:
-    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
-    steps:
-    # Machine Setup
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
-    - checkout
-    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
-    # In many cases you can simplify this from what is generated here.
-    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    # This is based on your 1.0 configuration file or project settings
-    - run:
-        working_directory: ~/Swrve/rate-limited-logger
-        command: sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/jdk1.8.0/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/jdk1.8.0" >> $BASH_ENV
-    # Dependencies
-    #   This would typically go in either a build or a build-and-test job when using workflows
-    # Restore the dependency cache
-    - restore_cache:
-        keys:
-        # This branch if available
-        - v1-dep-{{ .Branch }}-
-        # Default branch if not
-        - v1-dep-master-
-        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
-        - v1-dep-
-    # This is based on your 1.0 configuration file or project settings
-    - run: ./gradlew dependencies compileTestJava
-    # Save dependency cache
-    - save_cache:
-        key: v1-dep-{{ .Branch }}-{{ epoch }}
-        paths:
-        # This is a broad list of cache paths to include many possible development environments
-        # You can probably delete some of these entries
-        - vendor/bundle
-        - ~/virtualenvs
-        - ~/.m2
-        - ~/.ivy2
-        - ~/.bundle
-        - ~/.go_workspace
-        - ~/.gradle
-        - ~/.cache/bower
-    # Test
-    #   This would typically be a build job when using workflows, possibly combined with build
-    # This is based on your 1.0 configuration file or project settings
-    - run: ./gradlew all
-    # This is based on your 1.0 configuration file or project settings
-    - run: mkdir -p $CIRCLE_TEST_REPORTS/junit/
-    - run: find . -type f -regex "./build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-    # Teardown
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # Save test results
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    # Save artifacts
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: build/reports
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx2g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:11.0.3-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+      - image: circleci/postgres:12-alpine
+        auth:
+          username: mydockerhub-user
+          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: circle_test
+    steps: # a collection of executable commands
+      - checkout # check out source code to working directory
+      # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+      - restore_cache:
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - run:
+          name: Run tests in parallel # See: https://circleci.com/docs/2.0/parallelism-faster-jobs/
+          # Use "./gradlew test" instead if tests are not run in parallel
+          command: |
+            ./gradlew test
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v1-gradle-cache-{{ checksum "build.gradle" }}
+      - store_test_results:
+      # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: build/test-results/test
+      - store_artifacts: # Upload test results for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: build/test-results/test
+          when: always
+      - run:
+          name: Assemble JAR
+          command: |
+            # Skip this for other nodes
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+              ./gradlew assemble
+            fi
+      # As the JAR was only assembled in the first build container, build/libs will be empty in all the other build containers.
+      - store_artifacts:
+          path: build/libs
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+workflows:
+  version: 2
+  workflow:
+    jobs:
+    - build
+

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,9 @@ repositories {
 
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
-    compileOnly group: 'findbugs', name: 'annotations', version: '1.0.0'
-    compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '2.0.2'
+
+    compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.1.4'
+    compileOnly group: 'net.jcip', name: 'jcip-annotations', version: '1.0'
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'

--- a/src/main/java/com/swrve/ratelimitedlogger/LogWithPatternAndLevel.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/LogWithPatternAndLevel.java
@@ -3,9 +3,9 @@ package com.swrve.ratelimitedlogger;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
-import javax.annotation.concurrent.ThreadSafe;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLog.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLog.java
@@ -3,7 +3,7 @@ package com.swrve.ratelimitedlogger;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogBuilder.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogBuilder.java
@@ -2,8 +2,8 @@ package com.swrve.ratelimitedlogger;
 
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.NotThreadSafe;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import net.jcip.annotations.NotThreadSafe;
 import java.time.Duration;
 import java.util.Objects;
 

--- a/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/RateLimitedLogWithPattern.java
@@ -3,8 +3,8 @@ package com.swrve.ratelimitedlogger;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import net.jcip.annotations.ThreadSafe;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReferenceArray;

--- a/src/main/java/com/swrve/ratelimitedlogger/Registry.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/Registry.java
@@ -3,7 +3,7 @@ package com.swrve.ratelimitedlogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;

--- a/src/main/java/com/swrve/ratelimitedlogger/package-info.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/package-info.java
@@ -2,10 +2,12 @@
  * an SLF4J-compatible, simple, fluent API for rate-limited logging in Java; start with {@link com.swrve.ratelimitedlogger.RateLimitedLog}.
  */
 
-@ParametersAreNonnullByDefault
-@DefaultAnnotation(Nonnull.class)
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotation(NonNull.class)
+@DefaultAnnotationForParameters(NonNull.class)
 package com.swrve.ratelimitedlogger;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;


### PR DESCRIPTION
As noted at https://github.com/spotbugs/spotbugs/issues/130 and https://nipafx.dev/jsr-305-java-9 , there are problems with the JSR-305 FindBugs annotations we'd previously been using for nullability and thread-safety annotations. It seems the safest thing to do is switch to the Spotbugs and net.jcip annotations, instead, keeping them as compileOnly dependencies.