### PR TITLE
Avert GC pressure caused by long accidentally-interpolated log strings

### DIFF
--- a/src/main/java/com/swrve/ratelimitedlogger/LogWithPatternAndLevel.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/LogWithPatternAndLevel.java
@@ -92,6 +92,7 @@ public class LogWithPatternAndLevel {
         incrementStats();
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean isRateLimited() {
 
         // note: this method is not synchronized, for performance.  If we exceed the maxRate, we will start checking

--- a/src/main/java/com/swrve/ratelimitedlogger/Registry.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/Registry.java
@@ -71,6 +71,7 @@ class Registry {
                 try {
                     resetAllCounters(finalLogLinesForPeriod);
                 } catch (Exception e) {
+                    //noinspection AccessToStaticFieldLockedOnInstance
                     logger.warn("failed to reset counters: " + e, e);
                     // but carry on in the next iteration
                 }

--- a/src/main/java/com/swrve/ratelimitedlogger/Stopwatch.java
+++ b/src/main/java/com/swrve/ratelimitedlogger/Stopwatch.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class Stopwatch {
 
-    private long startTime = 0L;
+    private long startTime;
 
     public Stopwatch() {
         startTime = System.nanoTime();

--- a/src/test/java/com/swrve/ratelimitedlogger/RateLimitedLogTest.java
+++ b/src/test/java/com/swrve/ratelimitedlogger/RateLimitedLogTest.java
@@ -314,6 +314,33 @@ public class RateLimitedLogTest {
             rateLimitedLog.info("cache " + i);
             assertThat(logger.getInfoLastMessage().get(), equalTo("cache " + i)); // no loss
         }
+
+        assertThat(rateLimitedLog.knownPatterns.size(), equalTo(RateLimitedLog.MAX_PATTERNS_PER_LOG));
+    }
+
+    // Ensure that the out-of-cache-capacity logic doesn't lose data.
+    @Test
+    public void overlongKeyStrings() {
+        MockLogger logger = new MockLogger();
+        final AtomicLong mockTime = new AtomicLong(0L);
+
+        RateLimitedLog rateLimitedLog = RateLimitedLog.withRateLimit(logger)
+                .maxRate(1).every(Duration.ofMillis(10))
+                .withStopwatch(createStopwatch(mockTime))
+                .build();
+
+        StringBuilder s = new StringBuilder();
+        for (int i = 0; i < 400; i++) {
+            s.append("this string is too long for the cache "); // 38 chars
+        }
+        String overLongString = s.toString();
+
+        rateLimitedLog.info(overLongString + " 1");
+        rateLimitedLog.info(overLongString + " 2");
+
+        // check they shared the same rate limit
+        assertThat(logger.getInfoLastMessage().get(), equalTo(overLongString + " 1"));
+        assertThat(rateLimitedLog.knownPatterns.size(), equalTo(1));
     }
 
     private Stopwatch createStopwatch(final AtomicLong mockTime) {

--- a/src/test/java/com/swrve/ratelimitedlogger/RateLimitedLogTest.java
+++ b/src/test/java/com/swrve/ratelimitedlogger/RateLimitedLogTest.java
@@ -315,7 +315,8 @@ public class RateLimitedLogTest {
             assertThat(logger.getInfoLastMessage().get(), equalTo("cache " + i)); // no loss
         }
 
-        assertThat(rateLimitedLog.knownPatterns.size(), equalTo(RateLimitedLog.MAX_PATTERNS_PER_LOG));
+        // check that the cache was wiped once it filled up
+        assertThat(rateLimitedLog.knownPatterns.size(), equalTo(1));
     }
 
     // Ensure that the out-of-cache-capacity logic doesn't lose data.


### PR DESCRIPTION
This hit us recently in production -- a log string accidentally interpolated a very long multi-MB string, resulting in the rate limited logger's cache of patterns becoming very large, causing GC pressure. Avoid this risk by limiting the known patterns key length to 8192 chars.

The side effect of this is that logs which share the same first 8192 characters will share the same rate limit.